### PR TITLE
Allow ReactClass components to be extends from Component

### DIFF
--- a/src/utils/react.js
+++ b/src/utils/react.js
@@ -10,6 +10,9 @@ function extendsReactComponent(node: ClassDeclaration): boolean {
   if (superClass && superClass.type === "MemberExpression") {
     return superClass.object.name === "React" && superClass.property.name === "Component";
   }
+  if (superClass && superClass.type === "Identifier") {
+    return superClass.name === "Component";
+  }
   return false;
 }
 

--- a/test/fixture/fragment/extends_component/expected.js
+++ b/test/fixture/fragment/extends_component/expected.js
@@ -1,0 +1,50 @@
+/* @flow */
+import React, { Component } from "react";
+import Relay from "react-relay";
+
+
+type ArticleProps = {
+  article: {
+    title: string;
+    posted: string;
+    content: string;
+    views: number;
+    sponsored: bool;
+
+    author: {
+      name: string;
+      email: string;
+    };
+  }
+};
+
+class Article extends Component {
+  props: ArticleProps;
+
+  render() {
+    const { article } = this.props;
+    return <div>
+        <div>{article.title} ({article.posted})</div>
+        <div>{article.author.name} [{article.author.email}]</div>
+        <div>{article.content})</div>
+      </div>;
+  }
+}
+
+export default Relay.createContainer(Article, {
+  fragments: {
+    article: () => Relay.QL`
+fragment on Article {
+  title,
+  posted,
+  content,
+  views,
+  sponsored,
+  author {
+    name,
+    email
+  }
+}
+`
+  }
+});

--- a/test/fixture/fragment/extends_component/expected_combined.js
+++ b/test/fixture/fragment/extends_component/expected_combined.js
@@ -1,0 +1,106 @@
+/* @flow */
+import React, { Component } from "react";
+import Relay from "react-relay";
+
+
+type ArticleProps = {
+  article: {
+    title: string;
+    posted: string;
+    content: string;
+    views: number;
+    sponsored: bool;
+
+    author: {
+      name: string;
+      email: string;
+    };
+  }
+};
+
+class Article extends Component {
+  props: ArticleProps;
+
+  render() {
+    const { article } = this.props;
+    return <div>
+        <div>{article.title} ({article.posted})</div>
+        <div>{article.author.name} [{article.author.email}]</div>
+        <div>{article.content})</div>
+      </div>;
+  }
+}
+
+export default Relay.createContainer(Article, {
+  fragments: {
+    article: () => function () {
+      return {
+        children: [{
+          fieldName: "title",
+          kind: "Field",
+          metadata: {},
+          type: "String"
+        }, {
+          fieldName: "posted",
+          kind: "Field",
+          metadata: {},
+          type: "String"
+        }, {
+          fieldName: "content",
+          kind: "Field",
+          metadata: {},
+          type: "String"
+        }, {
+          fieldName: "views",
+          kind: "Field",
+          metadata: {},
+          type: "Int"
+        }, {
+          fieldName: "sponsored",
+          kind: "Field",
+          metadata: {},
+          type: "Boolean"
+        }, {
+          children: [{
+            fieldName: "name",
+            kind: "Field",
+            metadata: {},
+            type: "String"
+          }, {
+            fieldName: "email",
+            kind: "Field",
+            metadata: {},
+            type: "String"
+          }, {
+            fieldName: "id",
+            kind: "Field",
+            metadata: {
+              isGenerated: true,
+              isRequisite: true
+            },
+            type: "String"
+          }],
+          fieldName: "author",
+          kind: "Field",
+          metadata: {
+            canHaveSubselections: true
+          },
+          type: "Author"
+        }, {
+          fieldName: "id",
+          kind: "Field",
+          metadata: {
+            isGenerated: true,
+            isRequisite: true
+          },
+          type: "String"
+        }],
+        id: Relay.QL.__id(),
+        kind: "Fragment",
+        metadata: {},
+        name: "Source_ArticleRelayQL",
+        type: "Article"
+      };
+    }()
+  }
+});

--- a/test/fixture/fragment/extends_component/source.js
+++ b/test/fixture/fragment/extends_component/source.js
@@ -1,0 +1,40 @@
+/* @flow */
+import React, { Component } from "react";
+import Relay from "react-relay";
+import generateFragmentFromProps from "../../../../src/generateFragmentFromProps";
+
+type ArticleProps = {
+  article: {
+    title: string;
+    posted: string;
+    content: string;
+    views: number;
+    sponsored: boolean;
+
+    author: {
+      name: string;
+      email: string;
+    }
+  }
+};
+
+class Article extends Component {
+  props: ArticleProps;
+
+  render() {
+    const { article } = this.props;
+    return (
+      <div>
+        <div>{article.title} ({article.posted})</div>
+        <div>{article.author.name} [{article.author.email}]</div>
+        <div>{article.content})</div>
+      </div>
+    );
+  }
+}
+
+export default Relay.createContainer(Article, {
+  fragments: {
+    article: generateFragmentFromProps()
+  }
+});


### PR DESCRIPTION
I like to use destructing assignments imports and to extends directly from `Component`  :

``` jsx
import React, { Component } from "react";

class MyComponent extends Component {
...
}
```

This PR allows that and adds a test.

PS: Thanks for that plugin !!
