### PR TITLE
Allow for referenced types, rather than being forced to inline them

### DIFF
--- a/src/flowRelayQueryPlugin.js
+++ b/src/flowRelayQueryPlugin.js
@@ -217,7 +217,8 @@ export default function (schema: GraphQLSchema, options: PluginOptions = {}): (p
           fragmentDirectives,
           typeAtKey,
           state.componentContainerFragments,
-          childFragmentTransformations
+          childFragmentTransformations,
+          state.flowTypes
         );
 
         const templateTag = generateFragmentOptions.templateTag || defaultTemplateTag;

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -17,7 +17,10 @@ function flowTypeAnnotationToString(type: TypeTypeAnnotation): string {
 }
 
 // convert an ObjectTypeAnnotation to a js object
-export function convertFlowObjectTypeAnnotation(objectType: ObjectTypeAnnotation): FlowTypes {
+export function convertFlowObjectTypeAnnotation(
+  objectType: ObjectTypeAnnotation,
+  flowTypes: { [name: string ]: Object } = {}
+): FlowTypes {
   return objectType.properties.reduce((obj, property) => {
     const key = property.key.name;
     const value = property.value;
@@ -27,7 +30,18 @@ export function convertFlowObjectTypeAnnotation(objectType: ObjectTypeAnnotation
         [key]: {
           type: "object",
           nullable: property.optional,
-          properties: convertFlowObjectTypeAnnotation(value)
+          properties: convertFlowObjectTypeAnnotation(value, flowTypes)
+        }
+      };
+    }
+
+    if (value.type === "GenericTypeAnnotation" && value.id && flowTypes[value.id.name]) {
+      return {
+        ...obj,
+        [key]: {
+          type: "object",
+          nullable: property.optional,
+          properties: convertFlowObjectTypeAnnotation(flowTypes[value.id.name], flowTypes)
         }
       };
     }

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -19,7 +19,7 @@ function flowTypeAnnotationToString(type: TypeTypeAnnotation): string {
 // convert an ObjectTypeAnnotation to a js object
 export function convertFlowObjectTypeAnnotation(
   objectType: ObjectTypeAnnotation,
-  flowTypes: { [name: string ]: Object } = {}
+  flowTypes: { [name: string ]: ObjectTypeAnnotation } = {}
 ): FlowTypes {
   return objectType.properties.reduce((obj, property) => {
     const key = property.key.name;

--- a/src/utils/graphql.js
+++ b/src/utils/graphql.js
@@ -103,17 +103,34 @@ function compareFlowTypes(a: FlowTypes, b: FlowTypes, path: Array<string> = []):
   }, []);
 }
 
+function getObjectFromAnnotation(
+  typeAnnotation: Object,
+  flowTypes: { [name: string]: Object }
+): Object {
+  switch (typeAnnotation.type) {
+    case "ObjectTypeAnnotation":
+      return convertFlowObjectTypeAnnotation(typeAnnotation, flowTypes);
+    case "GenericTypeAnnotation":
+      return typeAnnotation.id && flowTypes[typeAnnotation.id.name]
+        ? convertFlowObjectTypeAnnotation(flowTypes[typeAnnotation.id.name], flowTypes)
+        : {};
+    default:
+      return {};
+  }
+}
+
 export function toGraphQLQueryString(
   fragmentName: ?string,
   fragmentType: string,
   fragmentDirectives: Object,
   objectType: ObjectTypeProperty,
   componentContainerFragments: { [name: string]: Array<string> },
-  childFragmentTransformations: ChildFragmentTransformations
+  childFragmentTransformations: ChildFragmentTransformations,
+  flowTypes: { [name: string]: Object }
 ): string {
   const fragmentKey = objectType.key.name;
   const typeAnnotation = objectType.value;
-  const obj = typeAnnotation.type === "ObjectTypeAnnotation" ? convertFlowObjectTypeAnnotation(typeAnnotation) : {};
+  const obj = getObjectFromAnnotation(typeAnnotation, flowTypes);
 
   const graphQlQueryBody = objectToGraphQLString(obj);
 

--- a/test/fixture/fragment/referenced_types/expected.js
+++ b/test/fixture/fragment/referenced_types/expected.js
@@ -1,0 +1,50 @@
+/* @flow */
+import React from "react";
+import Relay from "react-relay";
+
+import type { AuthorGraph } from "./type";
+
+type ArticleGraph = {
+  title: string;
+  posted: string;
+  content: string;
+  views: number;
+  sponsored: boolean;
+
+  author: AuthorGraph;
+};
+
+type ArticleProps = {
+  article: ArticleGraph
+};
+
+class Article extends React.Component {
+  props: ArticleProps;
+
+  render() {
+    const { article } = this.props;
+    return <div>
+        <div>{article.title} ({article.posted})</div>
+        <div>{article.author.name} [{article.author.email}]</div>
+        <div>{article.content}</div>
+      </div>;
+  }
+}
+
+export default Relay.createContainer(Article, {
+  fragments: {
+    article: () => Relay.QL`
+fragment on Article {
+  title
+  posted
+  content
+  views
+  sponsored
+  author {
+    name
+    email
+  }
+}
+`
+  }
+});

--- a/test/fixture/fragment/referenced_types/expected_combined.js
+++ b/test/fixture/fragment/referenced_types/expected_combined.js
@@ -1,0 +1,106 @@
+/* @flow */
+import React from "react";
+import Relay from "react-relay";
+
+import type { AuthorGraph } from "./type";
+
+type ArticleGraph = {
+  title: string;
+  posted: string;
+  content: string;
+  views: number;
+  sponsored: boolean;
+
+  author: AuthorGraph;
+};
+
+type ArticleProps = {
+  article: ArticleGraph
+};
+
+class Article extends React.Component {
+  props: ArticleProps;
+
+  render() {
+    const { article } = this.props;
+    return <div>
+        <div>{article.title} ({article.posted})</div>
+        <div>{article.author.name} [{article.author.email}]</div>
+        <div>{article.content}</div>
+      </div>;
+  }
+}
+
+export default Relay.createContainer(Article, {
+  fragments: {
+    article: () => function () {
+      return {
+        children: [{
+          fieldName: "title",
+          kind: "Field",
+          metadata: {},
+          type: "String"
+        }, {
+          fieldName: "posted",
+          kind: "Field",
+          metadata: {},
+          type: "String"
+        }, {
+          fieldName: "content",
+          kind: "Field",
+          metadata: {},
+          type: "String"
+        }, {
+          fieldName: "views",
+          kind: "Field",
+          metadata: {},
+          type: "Int"
+        }, {
+          fieldName: "sponsored",
+          kind: "Field",
+          metadata: {},
+          type: "Boolean"
+        }, {
+          children: [{
+            fieldName: "name",
+            kind: "Field",
+            metadata: {},
+            type: "String"
+          }, {
+            fieldName: "email",
+            kind: "Field",
+            metadata: {},
+            type: "String"
+          }, {
+            fieldName: "id",
+            kind: "Field",
+            metadata: {
+              isGenerated: true,
+              isRequisite: true
+            },
+            type: "String"
+          }],
+          fieldName: "author",
+          kind: "Field",
+          metadata: {
+            canHaveSubselections: true
+          },
+          type: "Author"
+        }, {
+          fieldName: "id",
+          kind: "Field",
+          metadata: {
+            isGenerated: true,
+            isRequisite: true
+          },
+          type: "String"
+        }],
+        id: Relay.QL.__id(),
+        kind: "Fragment",
+        metadata: {},
+        name: "Source_ArticleRelayQL",
+        type: "Article"
+      };
+    }()
+  }
+});

--- a/test/fixture/fragment/referenced_types/source.js
+++ b/test/fixture/fragment/referenced_types/source.js
@@ -1,0 +1,41 @@
+/* @flow */
+import React from "react";
+import Relay from "react-relay";
+import generateFragmentFromProps from "../../../../src/generateFragmentFromProps";
+import type { AuthorGraph } from "./type";
+
+
+type ArticleGraph = {
+  title: string;
+  posted: string;
+  content: string;
+  views: number;
+  sponsored: boolean;
+
+  author: AuthorGraph;
+};
+
+type ArticleProps = {
+  article: ArticleGraph;
+};
+
+class Article extends React.Component {
+  props: ArticleProps;
+
+  render() {
+    const { article } = this.props;
+    return (
+      <div>
+        <div>{article.title} ({article.posted})</div>
+        <div>{article.author.name} [{article.author.email}]</div>
+        <div>{article.content}</div>
+      </div>
+    );
+  }
+}
+
+export default Relay.createContainer(Article, {
+  fragments: {
+    article: generateFragmentFromProps()
+  }
+});

--- a/test/fixture/fragment/referenced_types/type.js
+++ b/test/fixture/fragment/referenced_types/type.js
@@ -1,0 +1,4 @@
+export type AuthorGraph = {
+  name: string;
+  email: string;
+};


### PR DESCRIPTION
Allows for referenced types. This becomes increasingly useful in deeply nested structures. Also made sure in the test that referencing imported structure worked.