### PR TITLE
Add support for list children

### DIFF
--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -16,7 +16,7 @@ function flowTypeAnnotationToString(type: TypeTypeAnnotation): string {
   }
 }
 
-function resolveFlowObjectTypeAnnotation(
+function resolveFlowTypeAnnotation(
   objectType: TypeTypeAnnotation,
   flowTypes: { [name: string ]: ObjectTypeAnnotation }
 ): TypeTypeAnnotation {
@@ -34,7 +34,7 @@ export function convertFlowObjectTypeAnnotation(
 ): FlowTypes {
   return objectType.properties.reduce((obj, property) => {
     const key = property.key.name;
-    const value = resolveFlowObjectTypeAnnotation(property.value, flowTypes);
+    const value = resolveFlowTypeAnnotation(property.value, flowTypes);
 
     if (value.type === "ObjectTypeAnnotation") {
       return {
@@ -48,7 +48,7 @@ export function convertFlowObjectTypeAnnotation(
     }
 
     if (value.type === "ArrayTypeAnnotation" && value.elementType) {
-      const children = resolveFlowObjectTypeAnnotation(value.elementType, flowTypes);
+      const children = resolveFlowTypeAnnotation(value.elementType, flowTypes);
 
       return {
         ...obj,

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -56,7 +56,7 @@ export function convertFlowObjectTypeAnnotation(
         [key]: {
           type: "array",
           nullable: property.optional,
-          children: convertFlowObjectTypeAnnotation(children, flowTypes)
+          children: children.properties ? convertFlowObjectTypeAnnotation(children, flowTypes) : null
         }
       };
     }

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -46,6 +46,21 @@ export function convertFlowObjectTypeAnnotation(
       };
     }
 
+    if (value.type === "ArrayTypeAnnotation" && value.elementType) {
+      const children = value.elementType.id && flowTypes[value.elementType.id.name]
+        ? flowTypes[value.elementType.id.name]
+        : value.elementType;
+
+      return {
+        ...obj,
+        [key]: {
+          type: "array",
+          nullable: property.optional,
+          children: convertFlowObjectTypeAnnotation(children, flowTypes)
+        }
+      };
+    }
+
     return {
       ...obj,
       [key]: {

--- a/src/utils/graphql.js
+++ b/src/utils/graphql.js
@@ -68,10 +68,12 @@ function graphqlFieldToString(field: Object): FlowType {
   }
 
   if (graphqlType instanceof GraphQLList) {
+    const children = graphqlFieldToString(graphqlType.ofType);
+
     return {
       type: "array",
       nullable,
-      children: convertGraphqlObjectType(graphqlType.ofType)
+      children: children.type === "object" ? convertGraphqlObjectType(graphqlType.ofType) : null
     };
   }
 
@@ -201,7 +203,7 @@ function objectToGraphQLString(obj: { [key: string]: FlowType }, level: number =
     if (value.type === "object") {
       str = `${str} {\n${objectToGraphQLString(value.properties, level + 1)}\n${indentation}}`;
     }
-    if (value.type === "array") {
+    if (value.type === "array" && value.children) {
       str = `${str} {\n${objectToGraphQLString(value.children, level + 1)}\n${indentation}}`;
     }
     parts.push(indentation + str);

--- a/src/utils/graphql.js
+++ b/src/utils/graphql.js
@@ -68,12 +68,10 @@ function graphqlFieldToString(field: Object): FlowType {
   }
 
   if (graphqlType instanceof GraphQLList) {
-    const children = graphqlFieldToString(graphqlType.ofType);
-
     return {
       type: "array",
       nullable,
-      children: children.type === "object" ? convertGraphqlObjectType(graphqlType.ofType) : null
+      children: graphqlType.ofType instanceof GraphQLObjectType ? convertGraphqlObjectType(graphqlType.ofType) : null
     };
   }
 

--- a/src/utils/graphql.js
+++ b/src/utils/graphql.js
@@ -1,5 +1,6 @@
 /* @flow */
 import {
+  GraphQLList,
   GraphQLObjectType,
   GraphQLNonNull,
   GraphQLScalarType
@@ -63,6 +64,14 @@ function graphqlFieldToString(field: Object): FlowType {
       type: "object",
       nullable,
       properties: convertGraphqlObjectType(graphqlType)
+    };
+  }
+
+  if (graphqlType instanceof GraphQLList) {
+    return {
+      type: "array",
+      nullable,
+      children: convertGraphqlObjectType(graphqlType.ofType)
     };
   }
 
@@ -191,6 +200,9 @@ function objectToGraphQLString(obj: { [key: string]: FlowType }, level: number =
     let str = key;
     if (value.type === "object") {
       str = `${str} {\n${objectToGraphQLString(value.properties, level + 1)}\n${indentation}}`;
+    }
+    if (value.type === "array") {
+      str = `${str} {\n${objectToGraphQLString(value.children, level + 1)}\n${indentation}}`;
     }
     parts.push(indentation + str);
     return parts;

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -8,7 +8,7 @@ type FlowAnyType = { type: "any", nullable: boolean };
 
 export type FlowScalarType = FlowBooleanType | FlowNumberType | FlowStringType | FlowAnyType;
 export type FlowObjectType = { type: "object", nullable: boolean, properties: FlowTypes };
-export type FlowArrayType = { type: "array", nullable: boolean, children: FlowTypes };
+export type FlowArrayType = { type: "array", nullable: boolean, children: FlowTypes | null };
 export type FlowType = FlowObjectType | FlowScalarType | FlowArrayType;
 
 export type FlowTypes = { [name: string]: FlowType }

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -8,6 +8,7 @@ type FlowAnyType = { type: "any", nullable: boolean };
 
 export type FlowScalarType = FlowBooleanType | FlowNumberType | FlowStringType | FlowAnyType;
 export type FlowObjectType = { type: "object", nullable: boolean, properties: FlowTypes };
-export type FlowType = FlowObjectType | FlowScalarType;
+export type FlowArrayType = { type: "array", nullable: boolean, children: FlowTypes };
+export type FlowType = FlowObjectType | FlowScalarType | FlowArrayType;
 
 export type FlowTypes = { [name: string]: FlowType }

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -8,7 +8,7 @@ type FlowAnyType = { type: "any", nullable: boolean };
 
 export type FlowScalarType = FlowBooleanType | FlowNumberType | FlowStringType | FlowAnyType;
 export type FlowObjectType = { type: "object", nullable: boolean, properties: FlowTypes };
-export type FlowArrayType = { type: "array", nullable: boolean, children: FlowTypes | null };
+export type FlowArrayType = { type: "array", nullable: boolean, children: ?FlowTypes };
 export type FlowType = FlowObjectType | FlowScalarType | FlowArrayType;
 
 export type FlowTypes = { [name: string]: FlowType }

--- a/test/data/articleSchema.js
+++ b/test/data/articleSchema.js
@@ -42,7 +42,8 @@ articleType = new GraphQLObjectType({
     content: { type: new GraphQLNonNull(GraphQLString) },
     views: { type: new GraphQLNonNull(GraphQLInt) },
     sponsored: { type: new GraphQLNonNull(GraphQLBoolean) },
-    author: { type: new GraphQLNonNull(authorType) }
+    author: { type: new GraphQLNonNull(authorType) },
+    tags: { type: new GraphQLList(GraphQLString) }
   })
 });
 

--- a/test/data/articleSchema.json
+++ b/test/data/articleSchema.json
@@ -198,6 +198,22 @@
               },
               "isDeprecated": false,
               "deprecationReason": null
+            },
+            {
+              "name": "tags",
+              "description": null,
+              "args": [],
+              "type": {
+                "kind": "LIST",
+                "name": null,
+                "ofType": {
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              "isDeprecated": false,
+              "deprecationReason": null
             }
           ],
           "inputFields": null,

--- a/test/fixture/fragment/lists/expected.js
+++ b/test/fixture/fragment/lists/expected.js
@@ -6,6 +6,7 @@ import Relay from "react-relay";
 type ArticleGraph = {
   title: string;
   posted: string;
+  tags: string[];
 };
 
 type AuthorGraph = {
@@ -26,7 +27,10 @@ class Author extends React.Component {
     return <div>
         <div>{author.name} ({author.email})</div>
         <ul>
-          {author.articles.map(article => <li>{article.title} ({article.posted})</li>)}
+          {author.articles.map(article => <li>
+              <div>{article.title} ({article.posted})</div>
+              <div>{article.tags.join(", ")}</div>
+            </li>)}
         </ul>
       </div>;
   }
@@ -41,6 +45,7 @@ fragment on Author {
   articles {
     title
     posted
+    tags
   }
 }
 `

--- a/test/fixture/fragment/lists/expected.js
+++ b/test/fixture/fragment/lists/expected.js
@@ -1,0 +1,48 @@
+/* @flow */
+import React from "react";
+import Relay from "react-relay";
+
+
+type ArticleGraph = {
+  title: string;
+  posted: string;
+};
+
+type AuthorGraph = {
+  name: string;
+  email: string;
+  articles?: ArticleGraph[];
+};
+
+type AuthorProps = {
+  author: AuthorGraph
+};
+
+class Author extends React.Component {
+  props: AuthorProps;
+
+  render() {
+    const { author } = this.props;
+    return <div>
+        <div>{author.name} ({author.email})</div>
+        <ul>
+          {author.articles.map(article => <li>{article.title} ({article.posted})</li>)}
+        </ul>
+      </div>;
+  }
+}
+
+export default Relay.createContainer(Author, {
+  fragments: {
+    author: () => Relay.QL`
+fragment on Author {
+  name
+  email
+  articles {
+    title
+    posted
+  }
+}
+`
+  }
+});

--- a/test/fixture/fragment/lists/expected_combined.js
+++ b/test/fixture/fragment/lists/expected_combined.js
@@ -6,6 +6,7 @@ import Relay from "react-relay";
 type ArticleGraph = {
   title: string;
   posted: string;
+  tags: string[];
 };
 
 type AuthorGraph = {
@@ -26,7 +27,10 @@ class Author extends React.Component {
     return <div>
         <div>{author.name} ({author.email})</div>
         <ul>
-          {author.articles.map(article => <li>{article.title} ({article.posted})</li>)}
+          {author.articles.map(article => <li>
+              <div>{article.title} ({article.posted})</div>
+              <div>{article.tags.join(", ")}</div>
+            </li>)}
         </ul>
       </div>;
   }
@@ -56,6 +60,13 @@ export default Relay.createContainer(Author, {
             fieldName: "posted",
             kind: "Field",
             metadata: {},
+            type: "String"
+          }, {
+            fieldName: "tags",
+            kind: "Field",
+            metadata: {
+              isPlural: true
+            },
             type: "String"
           }, {
             fieldName: "id",

--- a/test/fixture/fragment/lists/expected_combined.js
+++ b/test/fixture/fragment/lists/expected_combined.js
@@ -1,0 +1,93 @@
+/* @flow */
+import React from "react";
+import Relay from "react-relay";
+
+
+type ArticleGraph = {
+  title: string;
+  posted: string;
+};
+
+type AuthorGraph = {
+  name: string;
+  email: string;
+  articles?: ArticleGraph[];
+};
+
+type AuthorProps = {
+  author: AuthorGraph
+};
+
+class Author extends React.Component {
+  props: AuthorProps;
+
+  render() {
+    const { author } = this.props;
+    return <div>
+        <div>{author.name} ({author.email})</div>
+        <ul>
+          {author.articles.map(article => <li>{article.title} ({article.posted})</li>)}
+        </ul>
+      </div>;
+  }
+}
+
+export default Relay.createContainer(Author, {
+  fragments: {
+    author: () => function () {
+      return {
+        children: [{
+          fieldName: "name",
+          kind: "Field",
+          metadata: {},
+          type: "String"
+        }, {
+          fieldName: "email",
+          kind: "Field",
+          metadata: {},
+          type: "String"
+        }, {
+          children: [{
+            fieldName: "title",
+            kind: "Field",
+            metadata: {},
+            type: "String"
+          }, {
+            fieldName: "posted",
+            kind: "Field",
+            metadata: {},
+            type: "String"
+          }, {
+            fieldName: "id",
+            kind: "Field",
+            metadata: {
+              isGenerated: true,
+              isRequisite: true
+            },
+            type: "String"
+          }],
+          fieldName: "articles",
+          kind: "Field",
+          metadata: {
+            canHaveSubselections: true,
+            isPlural: true
+          },
+          type: "Article"
+        }, {
+          fieldName: "id",
+          kind: "Field",
+          metadata: {
+            isGenerated: true,
+            isRequisite: true
+          },
+          type: "String"
+        }],
+        id: Relay.QL.__id(),
+        kind: "Fragment",
+        metadata: {},
+        name: "Source_AuthorRelayQL",
+        type: "Author"
+      };
+    }()
+  }
+});

--- a/test/fixture/fragment/lists/source.js
+++ b/test/fixture/fragment/lists/source.js
@@ -6,6 +6,7 @@ import generateFragmentFromProps from "../../../../src/generateFragmentFromProps
 type ArticleGraph = {
   title: string;
   posted: string;
+  tags: string[];
 }
 
 type AuthorGraph = {
@@ -28,7 +29,10 @@ class Author extends React.Component {
         <div>{author.name} ({author.email})</div>
         <ul>
           {author.articles.map(article => (
-            <li>{article.title} ({article.posted})</li>
+            <li>
+              <div>{article.title} ({article.posted})</div>
+              <div>{article.tags.join(", ")}</div>
+            </li>
           ))}
         </ul>
       </div>

--- a/test/fixture/fragment/lists/source.js
+++ b/test/fixture/fragment/lists/source.js
@@ -1,0 +1,43 @@
+/* @flow */
+import React from "react";
+import Relay from "react-relay";
+import generateFragmentFromProps from "../../../../src/generateFragmentFromProps";
+
+type ArticleGraph = {
+  title: string;
+  posted: string;
+}
+
+type AuthorGraph = {
+  name: string;
+  email: string;
+  articles?: ArticleGraph[];
+}
+
+type AuthorProps = {
+  author: AuthorGraph;
+};
+
+class Author extends React.Component {
+  props: AuthorProps;
+
+  render() {
+    const { author } = this.props;
+    return (
+      <div>
+        <div>{author.name} ({author.email})</div>
+        <ul>
+          {author.articles.map(article => (
+            <li>{article.title} ({article.posted})</li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+}
+
+export default Relay.createContainer(Author, {
+  fragments: {
+    author: generateFragmentFromProps()
+  }
+});


### PR DESCRIPTION
Adds support for lists as a direct `property` on an object type. Works with both inline and referenced types.

Could potentially treat them as `FlowObjectType` given how they are consumed, but I was already down the path of treating them separately. `children` on `FlowArrayType` is exactly the same as `properties` on `FlowObjectType`. Seems like a valid distinction though.