### PR TITLE
Remove assumption of object types everywhere

### DIFF
--- a/flow/lib/ast.js
+++ b/flow/lib/ast.js
@@ -96,7 +96,13 @@ type TypeAlias = {
   right: TypeTypeAnnotation;
 }
 
-type TypeTypeAnnotation = BooleanTypeAnnotation | NumberTypeAnnotation | StringTypeAnnotation | ObjectTypeAnnotation;
+type TypeTypeAnnotation =
+  BooleanTypeAnnotation |
+  NumberTypeAnnotation |
+  StringTypeAnnotation |
+  ArrayTypeAnnotation |
+  ObjectTypeAnnotation |
+  GenericTypeAnnotation;
 
 type BooleanTypeAnnotation = {
   type: "BooleanTypeAnnotation";
@@ -108,6 +114,11 @@ type NumberTypeAnnotation = {
 
 type StringTypeAnnotation = {
   type: "StringTypeAnnotation";
+}
+
+type ArrayTypeAnnotation = {
+  type: "ArrayTypeAnnotation";
+  elementType: TypeTypeAnnotation;
 }
 
 type ObjectTypeAnnotation = {

--- a/src/flowRelayQueryPlugin.js
+++ b/src/flowRelayQueryPlugin.js
@@ -210,7 +210,7 @@ export default function (schema: GraphQLSchema, options: PluginOptions = {}): (p
         const fragmentName = generateFragmentOptions.name || defaultFragmentName(reactComponentName, fragmentType);
         const fragmentDirectives = generateFragmentOptions.directives || {};
 
-        checkPropsObjectTypeMatchesSchema(schema, fragmentType, typeAtKey);
+        checkPropsObjectTypeMatchesSchema(schema, fragmentType, typeAtKey, state.flowTypes);
         const graphQlQuery = toGraphQLQueryString(
           fragmentName,
           fragmentType,

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -8,7 +8,7 @@ type FlowAnyType = { type: "any", nullable: boolean };
 
 export type FlowScalarType = FlowBooleanType | FlowNumberType | FlowStringType | FlowAnyType;
 export type FlowObjectType = { type: "object", nullable: boolean, properties: FlowTypes };
-export type FlowArrayType = { type: "array", nullable: boolean, children: ?FlowTypes };
+export type FlowArrayType = { type: "array", nullable: boolean, child: FlowType };
 export type FlowType = FlowObjectType | FlowScalarType | FlowArrayType;
 
 export type FlowTypes = { [name: string]: FlowType }

--- a/test/fixture/fragment/lists/expected_combined.js
+++ b/test/fixture/fragment/lists/expected_combined.js
@@ -6,7 +6,7 @@ import Relay from "react-relay";
 type ArticleGraph = {
   title: string;
   posted: string;
-  tags: string[];
+  tags: ?string[];
 };
 
 type AuthorGraph = {

--- a/test/fixture/fragment/lists/source.js
+++ b/test/fixture/fragment/lists/source.js
@@ -6,7 +6,7 @@ import generateFragmentFromProps from "../../../../src/generateFragmentFromProps
 type ArticleGraph = {
   title: string;
   posted: string;
-  tags: string[];
+  tags: ?string[];
 }
 
 type AuthorGraph = {

--- a/test/fixture/fragment/mismatch_of_graphql_types_advanced/expected.js
+++ b/test/fixture/fragment/mismatch_of_graphql_types_advanced/expected.js
@@ -1,0 +1,4 @@
+{PROJECT_ROOT}/test/fixture/fragment/mismatch_of_graphql_types_advanced/source.js: Errors for fragment Author:
+Expected type 'string', actual type 'number' for path articles.posted
+Expected type '?array', actual type 'array' for path articles.tags
+Expected type 'string', actual type '?string' for path email

--- a/test/fixture/fragment/mismatch_of_graphql_types_advanced/expected_combined.js
+++ b/test/fixture/fragment/mismatch_of_graphql_types_advanced/expected_combined.js
@@ -1,0 +1,4 @@
+{PROJECT_ROOT}/test/fixture/fragment/mismatch_of_graphql_types_advanced/source.js: Errors for fragment Author:
+Expected type 'string', actual type 'number' for path articles.posted
+Expected type '?array', actual type 'array' for path articles.tags
+Expected type 'string', actual type '?string' for path email

--- a/test/fixture/fragment/mismatch_of_graphql_types_advanced/source.js
+++ b/test/fixture/fragment/mismatch_of_graphql_types_advanced/source.js
@@ -1,22 +1,22 @@
 /* @flow */
 import React from "react";
 import Relay from "react-relay";
-
+import generateFragmentFromProps from "../../../../src/generateFragmentFromProps";
 
 type ArticleGraph = {
   title: string;
-  posted: string;
-  tags: ?string[];
-};
+  posted: number;
+  tags: string[];
+}
 
 type AuthorGraph = {
   name: string;
-  email: string;
+  email: ?string;
   articles?: ArticleGraph[];
-};
+}
 
 type AuthorProps = {
-  author: AuthorGraph
+  author: AuthorGraph;
 };
 
 class Author extends React.Component {
@@ -24,30 +24,24 @@ class Author extends React.Component {
 
   render() {
     const { author } = this.props;
-    return <div>
+    return (
+      <div>
         <div>{author.name} ({author.email})</div>
         <ul>
-          {author.articles.map(article => <li>
+          {author.articles.map(article => (
+            <li>
               <div>{article.title} ({article.posted})</div>
               <div>{article.tags.join(", ")}</div>
-            </li>)}
+            </li>
+          ))}
         </ul>
-      </div>;
+      </div>
+    );
   }
 }
 
 export default Relay.createContainer(Author, {
   fragments: {
-    author: () => Relay.QL`
-fragment on Author {
-  name
-  email
-  articles {
-    title
-    posted
-    tags
-  }
-}
-`
+    author: generateFragmentFromProps()
   }
 });


### PR DESCRIPTION
Convert the Babel type annotation to flow type function to work on any
type not just object type annotations.

Convert the GraphQL type to flow type function to also work on any
GraphQLOutputType instead of only on GraphQL object types.

Update the printing and type checking functions that used FlowTypes to
instead use FlowType and handle objects and array flow types as special
cases.

These changes allow the flow type to GraphQL checker to work on any
types not just inline objects.