### PR TITLE
Updates graphql package dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "babel-plugin-syntax-trailing-function-commas": "^6.8.0",
 
     "babel-relay-plugin": "0.10.0",
-    "graphql": "0.8.2"
+    "graphql": "0.9.1"
   },
 
   "devDependencies": {


### PR DESCRIPTION
Straightforward. Main reason is for people running `flow-bin` > `0.37.4`.

Without this, cause downstream issues with people using `flow` due to changes addressed in https://github.com/graphql/graphql-js/commit/2646f4af2cb1523ec44121b26bb3a3040530d7b5

Didn't know if it makes sense to update other packages as well, but this one specifically is a problem with potential users of this plugin.