### PR TITLE
Derive array type child nullable-ness

### DIFF
--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -53,7 +53,6 @@ export function convertTypeAnnotationToFlowType(
   if (value.type === "ArrayTypeAnnotation") {
     return {
       type: "array",
-      nullable,
       child: convertTypeAnnotationToFlowType(value.elementType, nullable, flowTypes)
     };
   }

--- a/src/utils/graphql.js
+++ b/src/utils/graphql.js
@@ -72,7 +72,6 @@ function convertGraphqlTypeToFlowType(
   if (graphqlType instanceof GraphQLList) {
     return {
       type: "array",
-      nullable,
       child: convertGraphqlTypeToFlowType(graphqlType.ofType, true, objectTypeCache)
     };
   }

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -8,7 +8,7 @@ type FlowAnyType = { type: "any", nullable: boolean };
 
 export type FlowScalarType = FlowBooleanType | FlowNumberType | FlowStringType | FlowAnyType;
 export type FlowObjectType = { type: "object", nullable: boolean, properties: FlowTypes };
-export type FlowArrayType = { type: "array", nullable: boolean, child: FlowType };
+export type FlowArrayType = { type: "array", child: FlowType };
 export type FlowType = FlowObjectType | FlowScalarType | FlowArrayType;
 
 export type FlowTypes = { [name: string]: FlowType }

--- a/test/fixture/fragment/mismatch_of_graphql_types_advanced/expected.js
+++ b/test/fixture/fragment/mismatch_of_graphql_types_advanced/expected.js
@@ -1,4 +1,4 @@
 {PROJECT_ROOT}/test/fixture/fragment/mismatch_of_graphql_types_advanced/source.js: Errors for fragment Author:
 Expected type 'string', actual type 'number' for path articles.posted
-Expected type '?array', actual type 'array' for path articles.tags
+Expected type '?string', actual type 'string' for path articles.tags
 Expected type 'string', actual type '?string' for path email

--- a/test/fixture/fragment/mismatch_of_graphql_types_advanced/expected_combined.js
+++ b/test/fixture/fragment/mismatch_of_graphql_types_advanced/expected_combined.js
@@ -1,4 +1,4 @@
 {PROJECT_ROOT}/test/fixture/fragment/mismatch_of_graphql_types_advanced/source.js: Errors for fragment Author:
 Expected type 'string', actual type 'number' for path articles.posted
-Expected type '?array', actual type 'array' for path articles.tags
+Expected type '?string', actual type 'string' for path articles.tags
 Expected type 'string', actual type '?string' for path email


### PR DESCRIPTION
The only thing this might possibly make problematic is if you have a type like:

```graphql
type Article = ?{
  name: string
}
type Author = {
  articles? : Article[]
}
```

since `flowRelayQueryPlugin` is only looking for `ObjectTypeAnnotation`s, but it seems unlikely someone would do something like the above anyway.