### PR TITLE
Ignore optional object property

### DIFF
--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -21,10 +21,14 @@ function convertFlowObjectTypeAnnotation(
 ): FlowTypes {
   return objectType.properties.reduce((obj, property) => {
     const key = property.key.name;
+    // property.optional indicates the presence of a question mark at the end of a field
+    // eg. field?: blah
+    // given a GraphQL schema cannot represent an optional object key we don't need to care about it
+    const nullable = false;
 
     return {
       ...obj,
-      [key]: convertTypeAnnotationToFlowType(property.value, property.optional, flowTypes)
+      [key]: convertTypeAnnotationToFlowType(property.value, nullable, flowTypes)
     };
   }, {});
 }

--- a/test/data/articleSchema.js
+++ b/test/data/articleSchema.js
@@ -28,7 +28,7 @@ authorType = new GraphQLObjectType({
     twitter: { type: GraphQLString },
     editor: { type: new GraphQLNonNull(editorType) },
     articles: {
-      type: new GraphQLList(articleType)
+      type: new GraphQLList(new GraphQLNonNull(articleType))
     }
   })
 });

--- a/test/data/articleSchema.json
+++ b/test/data/articleSchema.json
@@ -330,9 +330,13 @@
                 "kind": "LIST",
                 "name": null,
                 "ofType": {
-                  "kind": "OBJECT",
-                  "name": "Article",
-                  "ofType": null
+                  "kind": "NON_NULL",
+                  "name": null,
+                  "ofType": {
+                    "kind": "OBJECT",
+                    "name": "Article",
+                    "ofType": null
+                  }
                 }
               },
               "isDeprecated": false,

--- a/test/fixture/fragment/lists/expected.js
+++ b/test/fixture/fragment/lists/expected.js
@@ -12,7 +12,7 @@ type ArticleGraph = {
 type AuthorGraph = {
   name: string;
   email: string;
-  articles?: ArticleGraph[];
+  articles: ArticleGraph[];
 };
 
 type AuthorProps = {

--- a/test/fixture/fragment/lists/expected_combined.js
+++ b/test/fixture/fragment/lists/expected_combined.js
@@ -12,7 +12,7 @@ type ArticleGraph = {
 type AuthorGraph = {
   name: string;
   email: string;
-  articles?: ArticleGraph[];
+  articles: ArticleGraph[];
 };
 
 type AuthorProps = {

--- a/test/fixture/fragment/lists/source.js
+++ b/test/fixture/fragment/lists/source.js
@@ -12,7 +12,7 @@ type ArticleGraph = {
 type AuthorGraph = {
   name: string;
   email: string;
-  articles?: ArticleGraph[];
+  articles: ArticleGraph[];
 }
 
 type AuthorProps = {

--- a/test/fixture/fragment/mismatch_of_graphql_types/expected.js
+++ b/test/fixture/fragment/mismatch_of_graphql_types/expected.js
@@ -1,5 +1,5 @@
 {PROJECT_ROOT}/test/fixture/fragment/mismatch_of_graphql_types/source.js: Errors for fragment Article:
-Expected type 'string', actual type '?number' for path author.email
+Expected type 'string', actual type 'number' for path author.email
 Expected type 'string', actual type '?string' for path author.name
 Expected type 'boolean', actual type 'number' for path sponsored
 Expected type 'string', actual type '?string' for path title

--- a/test/fixture/fragment/mismatch_of_graphql_types/expected_combined.js
+++ b/test/fixture/fragment/mismatch_of_graphql_types/expected_combined.js
@@ -1,5 +1,5 @@
 {PROJECT_ROOT}/test/fixture/fragment/mismatch_of_graphql_types/source.js: Errors for fragment Article:
-Expected type 'string', actual type '?number' for path author.email
+Expected type 'string', actual type 'number' for path author.email
 Expected type 'string', actual type '?string' for path author.name
 Expected type 'boolean', actual type 'number' for path sponsored
 Expected type 'string', actual type '?string' for path title


### PR DESCRIPTION
A GraphQL schema cannot represent an opptional object key so for a
better type comparision it should be ignored.