### PR TITLE
First attempt at supporting arguments

### DIFF
--- a/flow/lib/ast.js
+++ b/flow/lib/ast.js
@@ -102,7 +102,11 @@ type TypeTypeAnnotation =
   StringTypeAnnotation |
   ArrayTypeAnnotation |
   ObjectTypeAnnotation |
-  GenericTypeAnnotation;
+  FunctionTypeAnnotation |
+  GenericTypeAnnotation |
+  NumericLiteralTypeAnnotation |
+  BooleanLiteralTypeAnnotation |
+  StringLiteralTypeAnnotation;
 
 type BooleanTypeAnnotation = {
   type: "BooleanTypeAnnotation";
@@ -137,6 +141,33 @@ type VoidTypeAnnotation = {
   type: "VoidTypeAnnotation";
 }
 
+type FunctionTypeAnnotation = {
+  type: "FunctionTypeAnnotation";
+  params: FunctionTypeParam[];
+}
+
+type FunctionTypeParam = {
+  type: "FunctionTypeParam";
+  name: Identifier;
+  optional: boolean;
+  typeAnnotation: TypeTypeAnnotation;
+}
+
+type NumericLiteralTypeAnnotation = {
+  type: "NumericLiteralTypeAnnotation";
+  value: number;
+}
+
+type BooleanLiteralTypeAnnotation = {
+  type: "BooleanLiteralTypeAnnotation";
+  value: boolean;
+}
+
+type StringLiteralTypeAnnotation = {
+  type: "StringLiteralTypeAnnotation";
+  value: string;
+}
+
 
 type ClassProperty = {
   type: "ClassProperty";
@@ -159,7 +190,7 @@ type ClassBody = {
 
 type TypeParameterInstantiation = {
   type: "TypeParameterInstantiation";
-  params: Array<GenericTypeAnnotation | VoidTypeAnnotation>; // probably more types are valid as well
+  params: Array<TypeTypeAnnotation | VoidTypeAnnotation>; // probably more types are valid as well
 }
 
 type Literal = NullLiteral | StringLiteral | BooleanLiteral | NumericLiteral;

--- a/package.json
+++ b/package.json
@@ -3,7 +3,10 @@
   "version": "0.10.9",
   "description": "Babel plugin which converts Flow types into Relay fragments",
   "keywords": [
-    "babel-plugin", "relay", "flowtype", "apollo-client"
+    "babel-plugin",
+    "relay",
+    "flowtype",
+    "apollo-client"
   ],
   "license": "MIT",
   "repository": "guymers/babel-plugin-flow-relay-query",
@@ -11,14 +14,11 @@
   "files": [
     "lib"
   ],
-
   "scripts": {
     "update-schema": "babel-node test/data/updateSchema.js",
-
     "check": "npm run check:lint && npm run check:types",
     "check:lint": "eslint --ext .js .",
     "check:types": "flow check",
-
     "build": "rm -rf ./lib && babel src --out-dir lib --copy-files",
     "build-flow": "printf '%b' 'FragmentOptions.js\\0ChildFragmentTransformations.js\\0generateFragmentFromProps.js\\0generateFragmentFromPropsFor.js\\0markers.js\\0' | xargs -0 -I{} cp src/{} lib/{}.flow",
     "do-publish": "npm run check && npm run build && npm run build-flow && npm test && npm publish",
@@ -26,7 +26,6 @@
     "test": "mocha test/fixture",
     "coverage": "rm -rf coverage && NODE_ENV=test nyc npm test && nyc report"
   },
-
   "dependencies": {
     "babel-core": "^6.9.0",
     "babel-traverse": "^6.9.0",
@@ -42,13 +41,12 @@
     "babel-plugin-syntax-jsx": "^6.8.0",
     "babel-plugin-syntax-object-rest-spread": "^6.8.0",
     "babel-plugin-syntax-trailing-function-commas": "^6.8.0",
-
     "babel-relay-plugin": "0.10.0",
     "graphql": "0.9.1"
   },
-
   "devDependencies": {
     "babel-cli": "^6.9.0",
+    "babel-eslint": "7.1.1",
     "babel-preset-es2015": "^6.9.0",
     "babel-preset-react": "^6.5.0",
     "babel-preset-stage-2": "^6.5.0",

--- a/src/flowTypes.js.flow
+++ b/src/flowTypes.js.flow
@@ -1,2 +1,5 @@
 /* @flow */
 export type AliasFor<N: string, V: *> = V // eslint-disable-line no-unused-vars
+type _ExtractReturn<B, F: (...args: any[]) => B> = B; // eslint-disable-line no-unused-vars
+
+export type PropertyWithArgs<F> = _ExtractReturn<any, F>;

--- a/src/flowTypes.js.flow
+++ b/src/flowTypes.js.flow
@@ -2,4 +2,4 @@
 export type AliasFor<N: string, V: *> = V // eslint-disable-line no-unused-vars
 type _ExtractReturn<B, F: (...args: any[]) => B> = B; // eslint-disable-line no-unused-vars
 
-export type PropertyWithArgs<F> = _ExtractReturn<any, F>;
+export type PropertyWithArgs<F> = _ExtractReturn<*, F>;

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -93,7 +93,7 @@ export function convertTypeAnnotationToFlowType(
       fieldName,
       type: "object",
       nullable,
-      properties: convertFlowObjectTypeAnnotation(value, flowTypes, fieldName, variables)
+      fields: convertFlowObjectTypeAnnotation(value, flowTypes, fieldName, variables)
     };
   }
 

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -27,7 +27,8 @@ function flowTypeAnnotationToString(type: TypeTypeAnnotation, nullable: boolean,
 function convertFlowObjectTypeAnnotation(
   objectType: ObjectTypeAnnotation,
   flowTypes: { [name: string ]: ObjectTypeAnnotation },
-  fieldName?: string
+  fieldName?: string,
+  variables?: Object
 ): FlowTypes {
   return objectType.properties.reduce((obj, property) => {
     const key = property.key.name;
@@ -38,7 +39,7 @@ function convertFlowObjectTypeAnnotation(
 
     return {
       ...obj,
-      [key]: convertTypeAnnotationToFlowType(property.value, nullable, flowTypes, fieldName)
+      [key]: convertTypeAnnotationToFlowType(property.value, nullable, flowTypes, fieldName, variables)
     };
   }, {});
 }
@@ -77,13 +78,13 @@ export function convertTypeAnnotationToFlowType(
       if (value.id.name === "AliasFor") {
         const [fieldNameType, type] = value.typeParameters.params;
 
-        return convertTypeAnnotationToFlowType(type, nullable, flowTypes, fieldNameType.value);
+        return convertTypeAnnotationToFlowType(type, nullable, flowTypes, fieldNameType.value, variables);
       }
 
       if (value.id.name === "PropertyWithArgs") {
         const prop = value.typeParameters.params[0];
 
-        return convertTypeAnnotationToFlowType(prop.returnType, nullable, flowTypes, convertFunctionTypeAnnotation(prop, flowTypes));
+        return convertTypeAnnotationToFlowType(prop.returnType, nullable, flowTypes, fieldName, convertFunctionTypeAnnotation(prop, flowTypes));
       }
     }
   }
@@ -93,7 +94,7 @@ export function convertTypeAnnotationToFlowType(
       fieldName,
       type: "object",
       nullable,
-      fields: convertFlowObjectTypeAnnotation(value, flowTypes, fieldName, variables)
+      fields: convertFlowObjectTypeAnnotation(value, flowTypes, undefined, variables)
     };
   }
 

--- a/src/utils/graphql.js
+++ b/src/utils/graphql.js
@@ -65,7 +65,7 @@ function convertGraphqlTypeToFlowType(
     return {
       type: "object",
       nullable,
-      properties: convertGraphqlObjectType(graphqlType, objectTypeCache)
+      fields: convertGraphqlObjectType(graphqlType, objectTypeCache)
     };
   }
 
@@ -106,12 +106,12 @@ function compareFlowTypes(a: FlowType, b: FlowType, path: Array<string> = []): A
   // help flow, cant handle an &&
   let aProps = null;
   if (a.type === "object") {
-    aProps = a.properties;
+    aProps = a.fields;
   }
 
   let bProps = null;
   if (b.type === "object") {
-    bProps = b.properties;
+    bProps = b.fields;
   }
 
   if (aProps && bProps) {
@@ -228,7 +228,7 @@ function flowTypeToGraphQLString(flowType: FlowType, level: number = 1): string 
   if (flowType.type === "object") {
     const indentation = "  ".repeat(level);
 
-    const props = flowType.properties;
+    const props = flowType.fields;
     const strings = Object.keys(props).reduce((parts, key) => {
       const value = props[key];
       parts.push(`${indentation}${key}${args}${flowTypeToGraphQLString(value, level + 1)}`);

--- a/src/utils/graphql.js
+++ b/src/utils/graphql.js
@@ -209,6 +209,21 @@ export function toGraphQLQueryString(
 
 function flowTypeToGraphQLString(flowType: FlowType, level: number = 1): string {
   const fieldName = flowType.fieldName ? `: ${flowType.fieldName}` : "";
+  let args = "";
+
+  if (flowType.variables) {
+    const typeVariables = flowType.variables;
+    const variables = Object.keys(typeVariables).reduce((propArgs, variable) => {
+      const value = typeVariables[variable];
+
+      return [
+        ...propArgs,
+        `${variable}: ${value.value}`
+      ];
+    }, []);
+
+    args = `(${variables.join(", ")})`;
+  }
 
   if (flowType.type === "object") {
     const indentation = "  ".repeat(level);
@@ -216,7 +231,7 @@ function flowTypeToGraphQLString(flowType: FlowType, level: number = 1): string 
     const props = flowType.properties;
     const strings = Object.keys(props).reduce((parts, key) => {
       const value = props[key];
-      parts.push(`${indentation}${key}${flowTypeToGraphQLString(value, level + 1)}`);
+      parts.push(`${indentation}${key}${args}${flowTypeToGraphQLString(value, level + 1)}`);
       return parts;
     }, []);
 
@@ -225,7 +240,7 @@ function flowTypeToGraphQLString(flowType: FlowType, level: number = 1): string 
     return flowTypeToGraphQLString(flowType.child, level);
   }
 
-  return fieldName;
+  return `${fieldName}${args}`;
 }
 
 function directivesToGraphQLString(directives: Object): string {

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -1,14 +1,14 @@
 /* @flow */
 /* eslint no-use-before-define:0 */
 
-type FlowBooleanType = { type: "boolean", nullable: boolean, fieldName?: string };
-type FlowNumberType = { type: "number", nullable: boolean, fieldName?: string };
-type FlowStringType = { type: "string", nullable: boolean, fieldName?: string };
-type FlowAnyType = { type: "any", nullable: boolean, fieldName?: string };
+type FlowBooleanType = { type: "boolean", nullable: boolean, fieldName?: string, variables?: Object };
+type FlowNumberType = { type: "number", nullable: boolean, fieldName?: string, variables?: Object };
+type FlowStringType = { type: "string", nullable: boolean, fieldName?: string, variables?: Object };
+type FlowAnyType = { type: "any", nullable: boolean, fieldName?: string, variables?: Object };
 
 export type FlowScalarType = FlowBooleanType | FlowNumberType | FlowStringType | FlowAnyType;
-export type FlowObjectType = { type: "object", nullable: boolean, properties: FlowTypes, fieldName?: string };
-export type FlowArrayType = { type: "array", child: FlowType, fieldName?: string };
+export type FlowObjectType = { type: "object", nullable: boolean, properties: FlowTypes, fieldName?: string, variables?: Object };
+export type FlowArrayType = { type: "array", child: FlowType, fieldName?: string, variables?: Object };
 export type FlowType = FlowObjectType | FlowScalarType | FlowArrayType;
 
 export type FlowTypes = { [name: string]: FlowType }

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -5,9 +5,10 @@ type FlowBooleanType = { type: "boolean", nullable: boolean, fieldName?: string,
 type FlowNumberType = { type: "number", nullable: boolean, fieldName?: string, variables?: Object };
 type FlowStringType = { type: "string", nullable: boolean, fieldName?: string, variables?: Object };
 type FlowAnyType = { type: "any", nullable: boolean, fieldName?: string, variables?: Object };
+type FlowLiteralType = { type: "literal", nullable: boolean, fieldName?: string, variables?: Object, value: any }
 
-export type FlowScalarType = FlowBooleanType | FlowNumberType | FlowStringType | FlowAnyType;
-export type FlowObjectType = { type: "object", nullable: boolean, properties: FlowTypes, fieldName?: string, variables?: Object };
+export type FlowScalarType = FlowBooleanType | FlowNumberType | FlowStringType | FlowAnyType | FlowLiteralType;
+export type FlowObjectType = { type: "object", nullable: boolean, fields: FlowTypes, fieldName?: string, variables?: Object };
 export type FlowArrayType = { type: "array", child: FlowType, fieldName?: string, variables?: Object };
 export type FlowType = FlowObjectType | FlowScalarType | FlowArrayType;
 

--- a/test/data/articleSchema.js
+++ b/test/data/articleSchema.js
@@ -43,7 +43,13 @@ articleType = new GraphQLObjectType({
     views: { type: new GraphQLNonNull(GraphQLInt) },
     sponsored: { type: new GraphQLNonNull(GraphQLBoolean) },
     author: { type: new GraphQLNonNull(authorType) },
-    tags: { type: new GraphQLList(GraphQLString) }
+    tags: {
+      type: new GraphQLList(GraphQLString),
+      args: {
+        category: { type: GraphQLString },
+        first: { type: GraphQLInt }
+      }
+    }
   })
 });
 

--- a/test/data/articleSchema.json
+++ b/test/data/articleSchema.json
@@ -202,7 +202,28 @@
             {
               "name": "tags",
               "description": null,
-              "args": [],
+              "args": [
+                {
+                  "name": "category",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "String",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                },
+                {
+                  "name": "first",
+                  "description": null,
+                  "type": {
+                    "kind": "SCALAR",
+                    "name": "Int",
+                    "ofType": null
+                  },
+                  "defaultValue": null
+                }
+              ],
               "type": {
                 "kind": "LIST",
                 "name": null,

--- a/test/fixture/fragment/bad_variable_types/expected.js
+++ b/test/fixture/fragment/bad_variable_types/expected.js
@@ -1,0 +1,58 @@
+/* @flow */
+import React from "react";
+import Relay from "react-relay";
+
+
+import type { PropertyWithArgs } from "../../../../src/flowTypes.js.flow";
+
+type ArticleProps = {
+  article: {
+    title: string;
+    posted: string;
+    content: string;
+    views: number;
+    sponsored: boolean;
+    tags: ?PropertyWithArgs<(category: 1, first: "'1'") => string[]>;
+
+    author: {
+      name: string;
+      email: string;
+    };
+  }
+};
+
+class Article extends React.Component {
+  props: ArticleProps;
+
+  render() {
+    const { article } = this.props;
+    return <div>
+        <div>{article.title} ({article.posted})</div>
+        <div>{article.author.name} [{article.author.email}]</div>
+        <div>{article.tags}</div>
+        <div>{article.content}</div>
+      </div>;
+  }
+}
+
+export default Relay.createContainer(Article, {
+  initialVariables: {
+    category: "test"
+  },
+  fragments: {
+    article: () => Relay.QL`
+fragment on Article {
+  title
+  posted
+  content
+  views
+  sponsored
+  tags(category: 1, first: "1")
+  author {
+    name
+    email
+  }
+}
+`
+  }
+});

--- a/test/fixture/fragment/bad_variable_types/expected_combined.js
+++ b/test/fixture/fragment/bad_variable_types/expected_combined.js
@@ -41,7 +41,7 @@ export default Relay.createContainer(Article, {
   },
   fragments: {
     article: () => function () {
-      throw new Error("GraphQL validation error ``Argument \"category\" has invalid value 1.\nExpected type \"String\", found 1. Argument \"first\" has invalid value \"1\".\nExpected type \"Int\", found \"1\".`` in file `/Users/kalley/src/babel-plugin-flow-relay-query/test/fixture/fragment/bad_variable_types/source.js`. Try updating your GraphQL schema if an argument/field/type was recently added.");
+      throw new Error("GraphQL validation error ``Argument \"category\" has invalid value 1.\nExpected type \"String\", found 1. Argument \"first\" has invalid value \"1\".\nExpected type \"Int\", found \"1\".`` in file `{PROJECT_ROOT}/test/fixture/fragment/bad_variable_types/source.js`. Try updating your GraphQL schema if an argument/field/type was recently added.");
     }()
   }
 });

--- a/test/fixture/fragment/bad_variable_types/expected_combined.js
+++ b/test/fixture/fragment/bad_variable_types/expected_combined.js
@@ -1,0 +1,47 @@
+/* @flow */
+import React from "react";
+import Relay from "react-relay";
+
+
+import type { PropertyWithArgs } from "../../../../src/flowTypes.js.flow";
+
+type ArticleProps = {
+  article: {
+    title: string;
+    posted: string;
+    content: string;
+    views: number;
+    sponsored: boolean;
+    tags: ?PropertyWithArgs<(category: 1, first: "'1'") => string[]>;
+
+    author: {
+      name: string;
+      email: string;
+    };
+  }
+};
+
+class Article extends React.Component {
+  props: ArticleProps;
+
+  render() {
+    const { article } = this.props;
+    return <div>
+        <div>{article.title} ({article.posted})</div>
+        <div>{article.author.name} [{article.author.email}]</div>
+        <div>{article.tags}</div>
+        <div>{article.content}</div>
+      </div>;
+  }
+}
+
+export default Relay.createContainer(Article, {
+  initialVariables: {
+    category: "test"
+  },
+  fragments: {
+    article: () => function () {
+      throw new Error("GraphQL validation error ``Argument \"category\" has invalid value 1.\nExpected type \"String\", found 1. Argument \"first\" has invalid value \"1\".\nExpected type \"Int\", found \"1\".`` in file `/Users/kalley/src/babel-plugin-flow-relay-query/test/fixture/fragment/bad_variable_types/source.js`. Try updating your GraphQL schema if an argument/field/type was recently added.");
+    }()
+  }
+});

--- a/test/fixture/fragment/bad_variable_types/source.js
+++ b/test/fixture/fragment/bad_variable_types/source.js
@@ -1,0 +1,47 @@
+/* @flow */
+import React from "react";
+import Relay from "react-relay";
+import generateFragmentFromProps from "../../../../src/generateFragmentFromProps";
+
+import type { PropertyWithArgs } from "../../../../src/flowTypes.js.flow";
+
+type ArticleProps = {
+  article: {
+    title: string;
+    posted: string;
+    content: string;
+    views: number;
+    sponsored: boolean;
+    tags: ?PropertyWithArgs<(category: 1, first: "'1'") => string[]>;
+
+    author: {
+      name: string;
+      email: string;
+    }
+  }
+};
+
+class Article extends React.Component {
+  props: ArticleProps;
+
+  render() {
+    const { article } = this.props;
+    return (
+      <div>
+        <div>{article.title} ({article.posted})</div>
+        <div>{article.author.name} [{article.author.email}]</div>
+        <div>{article.tags}</div>
+        <div>{article.content}</div>
+      </div>
+    );
+  }
+}
+
+export default Relay.createContainer(Article, {
+  initialVariables: {
+    category: "test"
+  },
+  fragments: {
+    article: generateFragmentFromProps()
+  }
+});

--- a/test/fixture/fragment/variables/expected.js
+++ b/test/fixture/fragment/variables/expected.js
@@ -1,0 +1,58 @@
+/* @flow */
+import React from "react";
+import Relay from "react-relay";
+
+
+import type { PropertyWithArgs } from "../../../../src/flowTypes.js.flow";
+
+type ArticleProps = {
+  article: {
+    title: string;
+    posted: string;
+    content: string;
+    views: number;
+    sponsored: boolean;
+    tags: ?PropertyWithArgs<(category: "$category", first: 1) => string[]>;
+
+    author: {
+      name: string;
+      email: string;
+    };
+  }
+};
+
+class Article extends React.Component {
+  props: ArticleProps;
+
+  render() {
+    const { article } = this.props;
+    return <div>
+        <div>{article.title} ({article.posted})</div>
+        <div>{article.author.name} [{article.author.email}]</div>
+        <div>{article.tags}</div>
+        <div>{article.content}</div>
+      </div>;
+  }
+}
+
+export default Relay.createContainer(Article, {
+  initialVariables: {
+    category: "test"
+  },
+  fragments: {
+    article: () => Relay.QL`
+fragment on Article {
+  title
+  posted
+  content
+  views
+  sponsored
+  tags(category: $category, first: 1)
+  author {
+    name
+    email
+  }
+}
+`
+  }
+});

--- a/test/fixture/fragment/variables/expected_combined.js
+++ b/test/fixture/fragment/variables/expected_combined.js
@@ -1,0 +1,137 @@
+/* @flow */
+import React from "react";
+import Relay from "react-relay";
+
+
+import type { PropertyWithArgs } from "../../../../src/flowTypes.js.flow";
+
+type ArticleProps = {
+  article: {
+    title: string;
+    posted: string;
+    content: string;
+    views: number;
+    sponsored: boolean;
+    tags: ?PropertyWithArgs<(category: "$category", first: 1) => string[]>;
+
+    author: {
+      name: string;
+      email: string;
+    };
+  }
+};
+
+class Article extends React.Component {
+  props: ArticleProps;
+
+  render() {
+    const { article } = this.props;
+    return <div>
+        <div>{article.title} ({article.posted})</div>
+        <div>{article.author.name} [{article.author.email}]</div>
+        <div>{article.tags}</div>
+        <div>{article.content}</div>
+      </div>;
+  }
+}
+
+export default Relay.createContainer(Article, {
+  initialVariables: {
+    category: "test"
+  },
+  fragments: {
+    article: () => function () {
+      return {
+        children: [{
+          fieldName: "title",
+          kind: "Field",
+          metadata: {},
+          type: "String"
+        }, {
+          fieldName: "posted",
+          kind: "Field",
+          metadata: {},
+          type: "String"
+        }, {
+          fieldName: "content",
+          kind: "Field",
+          metadata: {},
+          type: "String"
+        }, {
+          fieldName: "views",
+          kind: "Field",
+          metadata: {},
+          type: "Int"
+        }, {
+          fieldName: "sponsored",
+          kind: "Field",
+          metadata: {},
+          type: "Boolean"
+        }, {
+          calls: [{
+            kind: "Call",
+            metadata: {},
+            name: "category",
+            value: {
+              kind: "CallVariable",
+              callVariableName: "category"
+            }
+          }, {
+            kind: "Call",
+            metadata: {},
+            name: "first",
+            value: {
+              kind: "CallValue",
+              callValue: 1
+            }
+          }],
+          fieldName: "tags",
+          kind: "Field",
+          metadata: {
+            isPlural: true
+          },
+          type: "String"
+        }, {
+          children: [{
+            fieldName: "name",
+            kind: "Field",
+            metadata: {},
+            type: "String"
+          }, {
+            fieldName: "email",
+            kind: "Field",
+            metadata: {},
+            type: "String"
+          }, {
+            fieldName: "id",
+            kind: "Field",
+            metadata: {
+              isGenerated: true,
+              isRequisite: true
+            },
+            type: "String"
+          }],
+          fieldName: "author",
+          kind: "Field",
+          metadata: {
+            canHaveSubselections: true
+          },
+          type: "Author"
+        }, {
+          fieldName: "id",
+          kind: "Field",
+          metadata: {
+            isGenerated: true,
+            isRequisite: true
+          },
+          type: "String"
+        }],
+        id: Relay.QL.__id(),
+        kind: "Fragment",
+        metadata: {},
+        name: "Source_ArticleRelayQL",
+        type: "Article"
+      };
+    }()
+  }
+});

--- a/test/fixture/fragment/variables/source.js
+++ b/test/fixture/fragment/variables/source.js
@@ -1,0 +1,47 @@
+/* @flow */
+import React from "react";
+import Relay from "react-relay";
+import generateFragmentFromProps from "../../../../src/generateFragmentFromProps";
+
+import type { PropertyWithArgs } from "../../../../src/flowTypes.js.flow";
+
+type ArticleProps = {
+  article: {
+    title: string;
+    posted: string;
+    content: string;
+    views: number;
+    sponsored: boolean;
+    tags: ?PropertyWithArgs<(category: "$category", first: 1) => string[]>;
+
+    author: {
+      name: string;
+      email: string;
+    }
+  }
+};
+
+class Article extends React.Component {
+  props: ArticleProps;
+
+  render() {
+    const { article } = this.props;
+    return (
+      <div>
+        <div>{article.title} ({article.posted})</div>
+        <div>{article.author.name} [{article.author.email}]</div>
+        <div>{article.tags}</div>
+        <div>{article.content}</div>
+      </div>
+    );
+  }
+}
+
+export default Relay.createContainer(Article, {
+  initialVariables: {
+    category: "test"
+  },
+  fragments: {
+    article: generateFragmentFromProps()
+  }
+});

--- a/test/fixture/index.js
+++ b/test/fixture/index.js
@@ -29,7 +29,9 @@ const createBabelOptions = plugin => ({
 });
 const customBabelOptions = options => createBabelOptions(createFlowRelayQueryPlugin(createSchema(schema.data), options));
 const babelOptions = customBabelOptions({});
-const itBabelOptions = createBabelOptions(pluginDef(schema.data));
+const itBabelOptions = createBabelOptions(pluginDef(schema.data, {
+  suppressWarnings: true
+}));
 
 function test(folder, options, expectedFile) {
   const optionsFile = path.resolve(folder, "options.js");


### PR DESCRIPTION
Fixes #12

I ended up going the route of exposing `type PropertyWithArgs`, that allows for the function syntax inside it, but the type itself only cares about the return type. So, the following things are equivalent from a type checking standpoint.

```js
// will generate arguments for relay/apollo
type Test = {
  tags: PropertyWithArgs<(category: "$category", first: 1) => string[]>;
}

// and
type Test = {
  tags: string[];
}
```

but the first compiles to:

```js
Relay.QL`
  fragment on Test {
    tags(category: $category, first: 1)
  }
`
```

The biggest downside is that in order to pass an actual string literal to an argument, you have to effectively pass `'"test"'`. It basically means you have to think about it like `JSON.stringify` (not the end of the world). But it does make it easy to pass in Enum values, as well as relay variables.

I was going to pass `args` to the fragment options, but it got messy really fast with string keys and it seems counterproductive to have to recreate your structure to provide args.

My biggest question is whether the literal types should all be treated differently (rather than all being `{ type: "literal", ...rest }`) or if it's fine as is.

Chances are pretty good I also don't have all the literal types added. I'll need to go through and add those if this seems like a good approach.