### PR TITLE
Support Field Aliasing

### DIFF
--- a/src/flowTypes.js.flow
+++ b/src/flowTypes.js.flow
@@ -1,0 +1,2 @@
+/* @flow */
+export type AliasFor<N: string, V: *> = V // eslint-disable-line no-unused-vars

--- a/src/utils/flow.js
+++ b/src/utils/flow.js
@@ -1,23 +1,24 @@
 /* @flow */
 import type { FlowType, FlowTypes } from "./types";
 
-function flowTypeAnnotationToString(type: TypeTypeAnnotation, nullable: boolean): FlowType {
+function flowTypeAnnotationToString(type: TypeTypeAnnotation, nullable: boolean, fieldName?: string): FlowType {
   switch (type.type) {
     case "BooleanTypeAnnotation":
-      return { type: "boolean", nullable };
+      return { type: "boolean", nullable, fieldName };
     case "NumberTypeAnnotation":
-      return { type: "number", nullable };
+      return { type: "number", nullable, fieldName };
     case "StringTypeAnnotation":
-      return { type: "string", nullable };
+      return { type: "string", nullable, fieldName };
     default:
-      return { type: "any", nullable };
+      return { type: "any", nullable, fieldName };
   }
 }
 
 // convert an ObjectTypeAnnotation to a js object
 function convertFlowObjectTypeAnnotation(
   objectType: ObjectTypeAnnotation,
-  flowTypes: { [name: string ]: ObjectTypeAnnotation }
+  flowTypes: { [name: string ]: ObjectTypeAnnotation },
+  fieldName?: string
 ): FlowTypes {
   return objectType.properties.reduce((obj, property) => {
     const key = property.key.name;
@@ -28,7 +29,7 @@ function convertFlowObjectTypeAnnotation(
 
     return {
       ...obj,
-      [key]: convertTypeAnnotationToFlowType(property.value, nullable, flowTypes)
+      [key]: convertTypeAnnotationToFlowType(property.value, nullable, flowTypes, fieldName)
     };
   }, {});
 }
@@ -36,18 +37,30 @@ function convertFlowObjectTypeAnnotation(
 export function convertTypeAnnotationToFlowType(
   value: TypeTypeAnnotation,
   nullable: boolean,
-  flowTypes: { [name: string ]: ObjectTypeAnnotation }
+  flowTypes: { [name: string ]: ObjectTypeAnnotation },
+  fieldName?: string
 ): FlowType {
   if (value.type === "NullableTypeAnnotation") {
-    return convertTypeAnnotationToFlowType(value.typeAnnotation, true, flowTypes);
+    return convertTypeAnnotationToFlowType(value.typeAnnotation, true, flowTypes, fieldName);
   }
 
-  if (value.type === "GenericTypeAnnotation" && flowTypes[value.id.name]) {
-    return convertTypeAnnotationToFlowType(flowTypes[value.id.name], nullable, flowTypes);
+  if (value.type === "GenericTypeAnnotation") {
+    if (flowTypes[value.id.name]) {
+      return convertTypeAnnotationToFlowType(flowTypes[value.id.name], nullable, flowTypes, fieldName);
+    }
+
+    if (value.typeParameters) {
+      if (value.id.name === "AliasFor") {
+        const [fieldNameType, type] = value.typeParameters.params;
+
+        return convertTypeAnnotationToFlowType(type, nullable, flowTypes, fieldNameType.value);
+      }
+    }
   }
 
   if (value.type === "ObjectTypeAnnotation") {
     return {
+      fieldName,
       type: "object",
       nullable,
       properties: convertFlowObjectTypeAnnotation(value, flowTypes)
@@ -57,9 +70,9 @@ export function convertTypeAnnotationToFlowType(
   if (value.type === "ArrayTypeAnnotation") {
     return {
       type: "array",
-      child: convertTypeAnnotationToFlowType(value.elementType, nullable, flowTypes)
+      child: convertTypeAnnotationToFlowType(value.elementType, nullable, flowTypes, fieldName)
     };
   }
 
-  return flowTypeAnnotationToString(value, nullable);
+  return flowTypeAnnotationToString(value, nullable, fieldName);
 }

--- a/src/utils/graphql.js
+++ b/src/utils/graphql.js
@@ -156,6 +156,7 @@ export function toGraphQLQueryString(
 
   // remove the first and last lines if flowType is an object as opening braces are added later
   let graphQlQueryBody = flowTypeToGraphQLString(flowType).trim();
+
   if (graphQlQueryBody) {
     if (graphQlQueryBody[0] === "{") {
       graphQlQueryBody = graphQlQueryBody.substr(graphQlQueryBody.indexOf("\n") + 1);
@@ -207,6 +208,8 @@ export function toGraphQLQueryString(
 }
 
 function flowTypeToGraphQLString(flowType: FlowType, level: number = 1): string {
+  const fieldName = flowType.fieldName ? `: ${flowType.fieldName}` : "";
+
   if (flowType.type === "object") {
     const indentation = "  ".repeat(level);
 
@@ -217,12 +220,12 @@ function flowTypeToGraphQLString(flowType: FlowType, level: number = 1): string 
       return parts;
     }, []);
 
-    return ` {\n${strings.join("\n")}\n${"  ".repeat(level - 1)}}`;
+    return `${fieldName} {\n${strings.join("\n")}\n${"  ".repeat(level - 1)}}`;
   } else if (flowType.type === "array") {
     return flowTypeToGraphQLString(flowType.child, level);
   }
 
-  return "";
+  return fieldName;
 }
 
 function directivesToGraphQLString(directives: Object): string {

--- a/src/utils/types.js
+++ b/src/utils/types.js
@@ -1,14 +1,14 @@
 /* @flow */
 /* eslint no-use-before-define:0 */
 
-type FlowBooleanType = { type: "boolean", nullable: boolean };
-type FlowNumberType = { type: "number", nullable: boolean };
-type FlowStringType = { type: "string", nullable: boolean };
-type FlowAnyType = { type: "any", nullable: boolean };
+type FlowBooleanType = { type: "boolean", nullable: boolean, fieldName?: string };
+type FlowNumberType = { type: "number", nullable: boolean, fieldName?: string };
+type FlowStringType = { type: "string", nullable: boolean, fieldName?: string };
+type FlowAnyType = { type: "any", nullable: boolean, fieldName?: string };
 
 export type FlowScalarType = FlowBooleanType | FlowNumberType | FlowStringType | FlowAnyType;
-export type FlowObjectType = { type: "object", nullable: boolean, properties: FlowTypes };
-export type FlowArrayType = { type: "array", child: FlowType };
+export type FlowObjectType = { type: "object", nullable: boolean, properties: FlowTypes, fieldName?: string };
+export type FlowArrayType = { type: "array", child: FlowType, fieldName?: string };
 export type FlowType = FlowObjectType | FlowScalarType | FlowArrayType;
 
 export type FlowTypes = { [name: string]: FlowType }

--- a/test/fixture/fragment/field_aliases/expected.js
+++ b/test/fixture/fragment/field_aliases/expected.js
@@ -1,0 +1,52 @@
+/* @flow */
+import React from "react";
+import Relay from "react-relay";
+
+
+import type { AliasFor } from "../../../../src/flowTypes.js.flow";
+
+type ArticleProps = {
+  article: {
+    title: string;
+    posted: string;
+    content: string;
+    views: number;
+    sponsored: boolean;
+
+    writer: AliasFor<'author', {
+      fullName: AliasFor<'name', string>;
+      email: string;
+    }>;
+  }
+};
+
+class Article extends React.Component {
+  props: ArticleProps;
+
+  render() {
+    const { article } = this.props;
+    return <div>
+        <div>{article.title} ({article.posted})</div>
+        <div>{article.writer.fullName} [{article.writer.email}]</div>
+        <div>{article.content}</div>
+      </div>;
+  }
+}
+
+export default Relay.createContainer(Article, {
+  fragments: {
+    article: () => Relay.QL`
+fragment on Article {
+  title
+  posted
+  content
+  views
+  sponsored
+  writer: author {
+    fullName: name
+    email
+  }
+}
+`
+  }
+});

--- a/test/fixture/fragment/field_aliases/expected_combined.js
+++ b/test/fixture/fragment/field_aliases/expected_combined.js
@@ -1,0 +1,110 @@
+/* @flow */
+import React from "react";
+import Relay from "react-relay";
+
+
+import type { AliasFor } from "../../../../src/flowTypes.js.flow";
+
+type ArticleProps = {
+  article: {
+    title: string;
+    posted: string;
+    content: string;
+    views: number;
+    sponsored: boolean;
+
+    writer: AliasFor<'author', {
+      fullName: AliasFor<'name', string>;
+      email: string;
+    }>;
+  }
+};
+
+class Article extends React.Component {
+  props: ArticleProps;
+
+  render() {
+    const { article } = this.props;
+    return <div>
+        <div>{article.title} ({article.posted})</div>
+        <div>{article.writer.fullName} [{article.writer.email}]</div>
+        <div>{article.content}</div>
+      </div>;
+  }
+}
+
+export default Relay.createContainer(Article, {
+  fragments: {
+    article: () => function () {
+      return {
+        children: [{
+          fieldName: "title",
+          kind: "Field",
+          metadata: {},
+          type: "String"
+        }, {
+          fieldName: "posted",
+          kind: "Field",
+          metadata: {},
+          type: "String"
+        }, {
+          fieldName: "content",
+          kind: "Field",
+          metadata: {},
+          type: "String"
+        }, {
+          fieldName: "views",
+          kind: "Field",
+          metadata: {},
+          type: "Int"
+        }, {
+          fieldName: "sponsored",
+          kind: "Field",
+          metadata: {},
+          type: "Boolean"
+        }, {
+          alias: "writer",
+          children: [{
+            alias: "fullName",
+            fieldName: "name",
+            kind: "Field",
+            metadata: {},
+            type: "String"
+          }, {
+            fieldName: "email",
+            kind: "Field",
+            metadata: {},
+            type: "String"
+          }, {
+            fieldName: "id",
+            kind: "Field",
+            metadata: {
+              isGenerated: true,
+              isRequisite: true
+            },
+            type: "String"
+          }],
+          fieldName: "author",
+          kind: "Field",
+          metadata: {
+            canHaveSubselections: true
+          },
+          type: "Author"
+        }, {
+          fieldName: "id",
+          kind: "Field",
+          metadata: {
+            isGenerated: true,
+            isRequisite: true
+          },
+          type: "String"
+        }],
+        id: Relay.QL.__id(),
+        kind: "Fragment",
+        metadata: {},
+        name: "Source_ArticleRelayQL",
+        type: "Article"
+      };
+    }()
+  }
+});

--- a/test/fixture/fragment/field_aliases/source.js
+++ b/test/fixture/fragment/field_aliases/source.js
@@ -1,0 +1,42 @@
+/* @flow */
+import React from "react";
+import Relay from "react-relay";
+import generateFragmentFromProps from "../../../../src/generateFragmentFromProps";
+
+import type { AliasFor } from "../../../../src/flowTypes.js.flow";
+
+type ArticleProps = {
+  article: {
+    title: string;
+    posted: string;
+    content: string;
+    views: number;
+    sponsored: boolean;
+
+    writer: AliasFor<'author', {
+      fullName: AliasFor<'name', string>;
+      email: string;
+    }>;
+  }
+};
+
+class Article extends React.Component {
+  props: ArticleProps;
+
+  render() {
+    const { article } = this.props;
+    return (
+      <div>
+        <div>{article.title} ({article.posted})</div>
+        <div>{article.writer.fullName} [{article.writer.email}]</div>
+        <div>{article.content}</div>
+      </div>
+    );
+  }
+}
+
+export default Relay.createContainer(Article, {
+  fragments: {
+    article: generateFragmentFromProps()
+  }
+});


### PR DESCRIPTION
Adds an `AliasFor` flowType that is exported, and used to support aliasing fields, such as (where `writer` and `fullName` are aliases for `author` and `name`, respectively):

```graphql
fragment on Article {
  writer: author {
    fullName: name;
  };
};
```